### PR TITLE
Require auth, add Support link, remove BMC script

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
 <body>
   <div id="app"></div>
   <script type="module" src="/src/main.ts"></script>
-    <script data-name="BMC-Widget" data-cfasync="false" src="https://cdnjs.buymeacoffee.com/1.0.0/widget.prod.min.js" data-id="jenuel.dev" data-description="Support me on Buy me a coffee!" data-message="Support this project ❤️ If this tool has been useful to you, consider making a small donation. Your support helps keep the service running and allows continuous improvements." data-color="#FF813F" data-position="Left" data-x_margin="18" data-y_margin="18"></script>
-  </body>
+</body>
 
 </html>

--- a/src/components/FamilyTree/FamilyTreeComponent.vue
+++ b/src/components/FamilyTree/FamilyTreeComponent.vue
@@ -6,6 +6,8 @@ import { useRoute } from "vue-router";
 import { getFamily, setFamily } from "@/util/firestore/families";
 import { Loading, Notify } from "notiflix";
 import SnapStorage from "snap-storage";
+import { getAuth } from "firebase/auth";
+import { app } from "@/util/firebase";
 
 const defaultFemaleImage = `https://cdn2.iconfinder.com/data/icons/peppyicons/512/women_blue-512.png`;
 const defaultMaleImage = `https://cdn2.iconfinder.com/data/icons/flat-style-svg-icons-part-1/512/user_man_male_profile_account-512.png`;
@@ -277,6 +279,7 @@ watch(
 );
 
 onMounted(async () => {
+    await getAuth(app).authStateReady();
     loadFamily();
 
     window.onbeforeunload = function (e) {

--- a/src/components/Header/HeaderComponent.vue
+++ b/src/components/Header/HeaderComponent.vue
@@ -126,6 +126,15 @@ async function logout() {
                         - {{ headerTitle }}
                     </p>
                 </div>
+                <a
+                    href="https://www.buymeacoffee.com/jenuel.dev"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="ml-2 hidden sm:flex items-center gap-1.5 rounded-xl border border-amber-200 bg-amber-50 px-3 py-1.5 text-sm font-600 text-amber-700 transition hover:bg-amber-100 no-underline"
+                >
+                    <Icon icon="noto:hot-beverage" class="text-base" />
+                    <span>Support</span>
+                </a>
             </div>
 
             <div

--- a/src/util/firestore/families.ts
+++ b/src/util/firestore/families.ts
@@ -73,6 +73,8 @@ export const getFamily = async (id: string) =>
             } else {
                 reject("No Such Document");
             }
+        } else {
+            reject("User not authenticated");
         }
     });
 


### PR DESCRIPTION
Remove the embedded BuyMeACoffee widget script from index.html and add a compact "Support" link/button in the header that opens the BuyMeACoffee page. In FamilyTreeComponent, import getAuth and app and await getAuth(app).authStateReady() before loading family data to ensure authentication is initialized. Update getFamily to reject with "User not authenticated" when no user is present, improving error handling for unauthenticated access.